### PR TITLE
pagination bugs fixed when using search query

### DIFF
--- a/projects/templates/projects/projects.html
+++ b/projects/templates/projects/projects.html
@@ -11,7 +11,7 @@
         </div>
 
         <div class="hero-section__search">
-          <form class="form" action="{% url 'projects' %}" method="get">
+          <form id="searchForm" class="form" action="{% url 'projects' %}" method="get">
             <div class="form__field">
               <label for="formInput#search">Search By Projects </label>
               <input class="input input--text" id="formInput#search" type="text" name="search_query"

--- a/projects/views.py
+++ b/projects/views.py
@@ -9,7 +9,7 @@ from .utils import searchProjects, paginateProjects
 # Create your views here.
 def projects(request):
     projects, search_query = searchProjects(request)
-    custom_range, projects = paginateProjects(request, projects, results = 2)
+    custom_range, projects = paginateProjects(request, projects, results = 6)
     
     context = {'projectList': projects, 'search_query': search_query, 
               'custom_range': custom_range}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,20 @@
+// Get SearchForm and Page Links
+let searchForm = document.getElementById('searchForm');
+let pageLinks = document.getElementsByClassName('page-link');
+// Ensure SearchForm Exists
+if (searchForm) {
+    for (let i = 0; pageLinks.length > i; i++) {
+        pageLinks[i].addEventListener('click', function (e) {
+            e.preventDefault();
+            // Get The Data Attribute
+            let page = this.dataset.page;
+            // console.log(page); 
+
+            // Add Hidden Search Input to Form
+            searchForm.innerHTML += `<input value=${page} name="page" 
+                hidden/>`
+            // Submit Form
+            searchForm.submit();
+        })
+    }
+}

--- a/templates/main.html
+++ b/templates/main.html
@@ -44,4 +44,5 @@
     {% endblock content %}
 </body>
 <script src="{% static 'uikit/app.js' %}"></script>
+<script src="{% static 'js/main.js' %}"></script>
 </html>

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -3,23 +3,25 @@
 {% if queryset.has_other_pages %}
     <div class="pagination">
       <ul class="container">
-        
+
         {% if queryset.has_previous %}
-        <li><a href="?page={{queryset.previous_page_number}}" class="btn page-link">&#10094; Prev</a></li>
+        <li><a href="?page={{queryset.previous_page_number}}" class="btn page-link" data-page="{{queryset.previous_page_number}}">&#10094; Prev</a></li>
         {% endif %}
 
         {% for page in custom_range%}
         {% if page == queryset.number %}
-          <li><a href="?page={{page}}" class="btn page-link btn--sub">{{page}}</a></li>
+          <li><a href="?page={{page}}" class="btn page-link btn--sub" data-page="{{page}}"> {{page}}</a></li>
         {% else  %}
-          <li><a href="?page={{page}}" class="btn page-link">{{page}}</a></li>
+          <li><a href="?page={{page}}" class="btn page-link" data-page="{{page}}">{{page}}</a></li>
         {% endif %}
         {% endfor %}
 
         {% if queryset.has_next %}
-        <li><a href="?page={{queryset.next_page_number}}" class="btn page-link">Next &#10095;</a></li>
+        <li><a href="?page={{queryset.next_page_number}}" class="btn page-link" 
+                data-page="{{queryset.next_page_number}}">Next &#10095;</a></li>
         {% endif %}
 
       </ul>
     </div>
 {% endif %}
+

--- a/users/views.py
+++ b/users/views.py
@@ -63,7 +63,7 @@ def registerUser(request):
 
 def profiles(request):
     profiles, search_query = searchProfiles(request)
-    custom_range, profiles = paginateProfiles(request, profiles, results = 3)
+    custom_range, profiles = paginateProfiles(request, profiles, results = 6)
     context = {"profiles": profiles, 'search_query': search_query,
                'custom_range': custom_range}
     return render(request, 'users/profiles.html', context)


### PR DESCRIPTION
FIXED: When we used to use search query to search a developer or projects, we used to get results like 3 filtered projects at one page, but the moment you click on next page, the search query used to vanish away.